### PR TITLE
Change TagsStream and SharedHierarchyStream primary_keys

### DIFF
--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -146,7 +146,7 @@ class TagsStream(ClickUpStream):
 
     name = "tag"
     path = "/space/{space_id}/tag"
-    primary_keys = ["id"]
+    primary_keys = ["name"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "tag.json"
     records_jsonpath = "$.tags[*]"
@@ -158,7 +158,7 @@ class SharedHierarchyStream(ClickUpStream):
 
     name = "shared_hierarchy"
     path = "/team/{team_id}/shared"
-    primary_keys = ["id"]
+    primary_keys = []
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "shared.json"
     records_jsonpath = "$.shared"


### PR DESCRIPTION
To comply with [singer specifications](https://github.com/singer-io/getting-started/blob/master/docs/SPEC.md#schema-message) key_properties needs to exist on top level (or be an empty list), of which Tags and Shared does not have ["id"].

To fix I found that changing the Tags primary key to be indexed by ["name"] would populate with all of the tags used.

For shared hierarchy, I set the primary index to be a null list because Its going to cause inconsistency, if being recorded at this time, as theres no ["id"] attributed to itself. Although, to add them its going to need to get_children and recursively add its shared tasks, lists, and folders