### PR TITLE
Removed format type "date-time" until transformation complete

### DIFF
--- a/tap_clickup/schemas/folder.json
+++ b/tap_clickup/schemas/folder.json
@@ -45,12 +45,10 @@
                         "type": ["null", "string", "integer"]
                     },
                     "due_date": {
-                        "type": ["null", "string"],
-                        "format": "date-time"
+                        "type": ["null", "string"]
                     },
                     "start_date": {
-                        "type": ["null", "string"],
-                        "format": "date-time"
+                        "type": ["null", "string"]
                     },
                     "space": {
                         "type": ["null", "object"],

--- a/tap_clickup/schemas/list.json
+++ b/tap_clickup/schemas/list.json
@@ -85,12 +85,10 @@
                 "type": ["null", "string", "integer"]
             },
         "due_date": {
-                "type": ["null", "string"],
-                "format": "date-time"
+                "type": ["null", "string"]
             },
         "start_date": {
-                "type": ["null", "string"],
-                "format": "date-time"
+                "type": ["null", "string"]
             },
         "folder": {
                 "$ref": "#definitions/folder"


### PR DESCRIPTION
This would be a temporary fix to the error occurring with the `date-time` format. For the time being until there is an implementation for epoch->rfc3339 datetime transformation.