### PR TITLE
Custom fields can also be jsonobjects, specefically manual_progress_t…

### DIFF
--- a/tap_clickup/schemas/task.json
+++ b/tap_clickup/schemas/task.json
@@ -220,7 +220,7 @@
                             "type": ["string", "boolean", "null"]
                         },
                         "value": {
-                            "type": ["integer", "string", "boolean", "null", "array"]
+                            "type": ["integer", "string", "boolean", "null", "array", "object"]
                         }
                     }
                 }


### PR DESCRIPTION
Closes #72 

Could replicate by adding manual and automatic progress types to clickup 