### PR TITLE
Time Entries docs update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Test tap-clickup 
         run: |
           poetry run tox -e test
-          pip install meltano
+          pip install meltano==2.7.1
           meltano install
           meltano elt tap-clickup target-jsonl
         env:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Note that the most up to date information is located in tap_clickup/streams.py. 
 
 ### Time Entries
 - Table name: time_entries
-- Description: All time entries are pulled for every team. Didn't do incremental as we have https://github.com/AutoIDM/tap-clickup/issues/95 open still 
+- Description: All time entries are pulled for every team. Currently only pulls the last 30 days of time_entries see https://github.com/AutoIDM/tap-clickup/issues/134 for an issue addressing this!
 - Primary key column(s):  id
 - Replicated fully or incrementally: Full
 - Bookmark column(s): N/A

--- a/meltano.yml
+++ b/meltano.yml
@@ -58,3 +58,5 @@ plugins:
       s3_region_name: us-west-2
       default_target_schema: tap_clickup
       primary_key_required: False
+environments:
+- name: dev


### PR DESCRIPTION
https://github.com/AutoIDM/tap-clickup/issues/134 brought up that Time Entries is only 30 days. Updating the docs to reflect this 