### PR TITLE
Bug fix on tasks.Json structure becausecustom fields were wrongfully set as bool

### DIFF
--- a/tap_clickup/schemas/task.json
+++ b/tap_clickup/schemas/task.json
@@ -226,7 +226,7 @@
                             "type": ["string", "boolean", "null"]
                         },
                         "value": {
-                            "type": ["integer", "string", "boolean", "null", "array", "object", "number"]
+                            "type": ["integer", "string", "null", "array", "object", "number"]
                         }
                     }
                 }


### PR DESCRIPTION
### Description
When fetching custom fields the tap would wrongfullly set it's values to boolean, when the values were supposed to be kept as integer or even strings.
For example directly calling clickup's API trough postman we would get this response
```
{
		"id": "4a3345d7-0c92-4968-8624-f588f8cbb6c2",
		"name": "Tipo De Fornecedor",
		"type": "drop_down",
		"type_config": {
			"options": [
				{
					"id": "4c73795f-7cc8-44da-b28a-a1d749be5482",
					"name": "Nacional",
					"color": null,
					"orderindex": 0
				},
				{
					"id": "eac699fe-772c-40d9-8f9e-6e5a07abb436",
					"name": "Importado",
					"color": null,
					"orderindex": 1
				}
			]
		},
		"date_created": "1681386787939",
		"hide_from_guests": false,
		"value": 0,
		"required": false
	}
```
However the tap would set  _**"value": false**_  instead of keeping it as 0 which in turn messed up the parsing of the entry later on. The same happened to other value types as well, such as strings, they would be set as true if there were any string set instead of returning the string itself.

### Change
Altered the task.json structure removing the boolean from the typage options since. per API documentation and testing, Click up returns booleans as 0 or 1 which in "values" field can be mistaken with regular integers