### PR TITLE
Feature to add a filtering options on the API call

### DIFF
--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -4,6 +4,50 @@ from typing import Optional, Any, Dict
 import requests
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from tap_clickup.client import ClickUpStream
+import yaml #added to read information specifying spaces and workspaces
+
+# Load the YAML config file from meltano
+with open("meltano.yml", "r") as yaml_file:
+    cu_config = yaml.safe_load(yaml_file)
+
+#funcions to read the extra configuration data from the YAML file
+#read and split lists to create list
+def extract_and_convert_list(config, key):
+    value = config.get(key, "")
+    if value:
+        split_values = value.split(',')
+        return [int(item) for item in split_values]
+    return []
+
+#specify which setting from which tap to read the config.info from ISSUE HERE the yaml read is hardcoded so breaks when i have multiple "tap-clickup" one for each env that i want to switch between
+def find_tap_clickup_config(plugins):
+    for plugin in plugins:
+        if plugin.get("name") == "tap-clickup":
+            return plugin.get("config", {})
+    return {}
+
+# Find the tap-clickup configuration
+tap_clickup_config = find_tap_clickup_config(cu_config["plugins"]["extractors"])
+
+# Extract and convert workspace ID
+cu_workspace = tap_clickup_config.get("workspace_id")
+
+# Extract and convert spaces and lists into lists
+spaces_id_list = extract_and_convert_list(tap_clickup_config, "spaces_id")
+lists_id_list = extract_and_convert_list(tap_clickup_config, "list_ids")
+
+workteamid = cu_workspace  # store workspace id E.g:30979640  
+space_ids = spaces_id_list # store list of spaces to be fetched E.g: [90100432266,90100432289,90100437857]
+list_ids = lists_id_list #store lists of  lists to be fetched E.g: [900101856869,901002404954]
+
+# Check if there's only one value in the list, this is necessary because of a bug on click up's API. 
+if len(list_ids) == 1:
+    # Duplicate the value to ensure at least two parameters due to a bug on clickups API (the values returned by the API are NOT duplicated)
+    list_ids.append(list_ids[0])
+if len(space_ids) == 1:
+    # Duplicate the value to ensure at least two parameters due to a bug on clickups API (the values returned by the API are NOT duplicated)
+    space_ids.append(space_ids[0])    
+
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
@@ -16,13 +60,16 @@ class TeamsStream(ClickUpStream):
     primary_keys = ["id"]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "team.json"
-    records_jsonpath = "$.teams[*]"
+    # Necessary because if you have access to multiple workteams, the responses are replicated N times where N = # of worspaces you have access to
+    records_jsonpath = f"$.teams[?(@.id == {workteamid})]" 
+    
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
         return {
             "team_id": record["id"],
         }
+
 
 
 class TimeEntries(ClickUpStream):
@@ -220,7 +267,6 @@ class TasksStream(ClickUpStream):
 
     name = "task"
     # Date_updated_gt is greater than or equal to not just greater than
-    path = "/team/{team_id}/task"
     primary_keys = ["id"]
     replication_key = "date_updated"
     is_sorted = True
@@ -228,12 +274,19 @@ class TasksStream(ClickUpStream):
     schema_filepath = SCHEMAS_DIR / "task.json"
     records_jsonpath = "$.tasks[*]"
     parent_stream_type = TeamsStream
-
     # Need this stub as a hack on _sync to force it to use Partitions
     # Since this is a child stream we want each team_id to create a request for
     # archived:true and archived:false. And we want state to track properly
     partitions = []
-
+    basepath = "/team/{team_id}/task"
+    space_ids_param = "&space_ids=" + "&space_ids=".join(map(str, space_ids)) if space_ids else "" #Dinamically create the spaces path to be passed on API call
+    list_ids_param = "?list_ids=" + "&list_ids=".join(map(str, list_ids)) if list_ids else "" #Dinamically create the spaces path to be passed on API call
+    # Necessary because if you pass list and space, lists MUST go first in the parameter string
+    if list_ids_param:
+        path = f"{basepath}{list_ids_param}{space_ids_param}"
+    else:
+        path = f"{basepath}?{space_ids_param}"
+   
     @property
     def base_partition(self):
         return [{"archived": "true"}, {"archived": "false"}]
@@ -262,7 +315,6 @@ class TasksStream(ClickUpStream):
 
         for _ in extract_jsonpath(self.records_jsonpath, input=response.json()):
             recordcount = recordcount + 1
-
         # I wonder if a better approach is to just check for 0 records and stop
         # For now I'll follow the docs verbatium
         # From the api docs, https://clickup.com/api.

--- a/tap_clickup/tap.py
+++ b/tap_clickup/tap.py
@@ -47,6 +47,15 @@ class TapClickUp(Tap):
         th.Property(
             "api_token", th.StringType, required=True, description="Example: 'pk_12345"
         ),
+        th.Property(
+            "workspace_id", th.IntegerType, required=False, description="Example: '20214542" # fetches the data for workspace_id
+        ),
+        th.Property(
+            "spaces_id", th.StringType, required=False, description="Example: '[45215477,4547547]" # fetches the data for workspace_id
+        ),
+        th.Property(
+            "list_ids", th.StringType, required=False, description="Example: '[454455478,784552187]" # fetches the data for workspace_id
+        ),                
         # Removing "official" start_date support re https://github.com/AutoIDM/tap-clickup/issues/118
         #        th.Property(
         #            "start_date",
@@ -64,3 +73,4 @@ class TapClickUp(Tap):
     def discover_streams(self) -> List[Stream]:
         """Return a list of discovered streams."""
         return [stream_class(tap=self) for stream_class in STREAM_TYPES]
+    


### PR DESCRIPTION
### Description
When dealing with enterprise workspaces in ClickUp, as ClickUp admins, we often find ourselves having access to multiple workspaces, lists, tasks, and other elements that are not needed in our pipeline. To save resources, processing time, and improve efficiency, it is beneficial for us to have the ability to filter specific elements that we want to fetch.

### Noteworthy ClickUp API Bugs
During the development of this project, I encountered some inherent bugs in ClickUp's API. Primarily, these bugs prevented the passing of a single space or list as a parameter. However, a workaround was discovered: by passing the same ID twice, the API would function correctly, and there are not any duplicate values in the API response.

### Issues

1. The following changes have been implemented and work, but they are currently coded to only fetch data from the general settings in the meltano.yml file. Consequently, it is not possible to configure different pipelines for various environments because they are not being correctly read. 

For example, when using the command meltano --environment=dev run tap-clickup ..., the configurations are not being applied as expected from the dev envv because it reads only from the common configurations.

Taking this meltano.yml sample, the code always reads "spaces_id" as '90100424497' even when we run it in prod (which in this case should be '90070255202'
```
version: 1
default_environment: prod
project_id: 8f483ca8-e13c-4abb-8d24-666666666
environments:
- name: prod
  config:
    plugins:
      extractors:
      - name: tap-clickup
        variant: autoidm
        pip_url: tap-clickup
        config:
          workspace_id: 30979640
          spaces_id: '90070255202'
          list_ids: ''
        select:
        - space.name
        - space.id
        - task.*
      loaders:...
plugins:
  extractors:
  - name: tap-clickup
    variant: autoidm
    pip_url: tap-clickup
    config:
      workspace_id: 30979640
      spaces_id: '90100424497'
      list_ids: ''
    select:
    - space.name
    - space.id
    - task.*
  loaders:...
```

2. Could not figure out how to correctly add the new setting in the meltano.yml file. At first I was just hardcoding it to the file, then I found  out about  **tap-clickup--autoidm.lock** file  and in this file I added the new configuration settings to be added when using meltano config tap-clickup -set. But I cannot figure out how to edit this into the projects code, i basically added these configs to the og file:
```
. . .
    {
      "name": "stream_map_config",
      "kind": "object",
      "label": "Stream Map Config",
      "description": "User-defined config values to be used within map expressions."
    },
    {
      "name": "stream_maps",
      "kind": "object",
      "label": "Stream Maps",
      "description": "Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html)."
    },
	    {
      "name": "workspace_id",
      "kind": "integer",
      "label": "Workspace Id",
      "description": "To limit from which workspace to fetch data pass it's id(https://dev-doc.clickup.com/333/d/h/ad-455845/c464293970a6906)."
    },
	    {
      "name": "spaces_id",
      "kind": "string",
      "label": "Spaces Ids",
      "description": "To limit from which Spaces to fetch data from, pass their ids as a list string Example: spaceid1,spaceid2,ispaced3."
    },
	    {
      "name": "list_ids",
      "kind": "string",
      "label": "Lists Ids",
      "description": "To limit from which Lists to fetch data from, pass their ids as a list string Example: listid1,listid2,listid3."
    }
  ]
}
```