### PR TITLE
Provide user ids in team + time entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ Want to become a sponsor? Reach out to us at [autoidm.com](https://autoidm.com)
 
 ## Settings
 
-| Setting             | Required | Default | Description |
-|:--------------------|:--------:|:-------:|:------------|
-| api_token           | True     | None    | Example: 'pk_12345 |
-| stream_maps         | False    | None    | Config object for stream maps capability. |
-| stream_map_config   | False    | None    | User-defined config values to be used within map expressions. |
-| flattening_enabled  | False    | None    | 'True' to enable schema flattening and automatically expand nested properties. |
-| flattening_max_depth| False    | None    | The max depth to flatten schemas. |
+| Setting               | Required | Default | Description                                                                                                                                                                                                                                                                                                                                                    |
+|:----------------------|:--------:|:-------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| api_token             |   True   |  None   | Example: 'pk_12345                                                                                                                                                                                                                                                                                                                                             |
+| time_entry_assignees  |  False   |  None   | By default, the extractor will get all user ids from your team and use them when fetching time entries. If you want to fetch time entries assigned to specific users, provide a comma-separated list of user IDs here. Ex. '420230,452346,784219'                                                                                                              |
+| time_entry_start_date |  False   |  None   | The start date that determines how far back in time the extractor gets time entries. Without this, only the last thirty days of time entries will be fetched. After the initial run, this value will be ignored in favor of the state, using the replication_key of 'at' to determine the start date. Ex. '2023-01-01T00:00:00Z' to follow singer date format. |
+| stream_maps           |  False   |  None   | Config object for stream maps capability.                                                                                                                                                                                                                                                                                                                      |
+| stream_map_config     |  False   |  None   | User-defined config values to be used within map expressions.                                                                                                                                                                                                                                                                                                  |
+| flattening_enabled    |  False   |  None   | 'True' to enable schema flattening and automatically expand nested properties.                                                                                                                                                                                                                                                                                 |
+| flattening_max_depth  |  False   |  None   | The max depth to flatten schemas.                                                                                                                                                                                                                                                                                                                              |
 
 A full list of supported settings and capabilities is available by running: `tap-clickup --about`
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Note that the most up to date information is located in tap_clickup/streams.py. 
 - Table name: time_entries
 - Description: All time entries are pulled for every team. Currently only pulls the last 30 days of time_entries see https://github.com/AutoIDM/tap-clickup/issues/134 for an issue addressing this!
 - Primary key column(s):  id
-- Replicated fully or incrementally: Full
-- Bookmark column(s): N/A
+- Replicated fully or incrementally: Incremental
+- Bookmark column(s): at. _Please note that you must set the start date in the config to get time entries older than 30 days._
 - Link to API endpoint documentation: [Time Entries](https://jsapi.apiary.io/apis/clickup20/reference/0/time-tracking-legacy/get-time-entries-within-a-date-range.html)
 
 ### Folders

--- a/meltano.yml
+++ b/meltano.yml
@@ -13,6 +13,8 @@ plugins:
     settings:
     - name: api_token
       kind: password
+    - name: time_entry_assignees
+      kind: string
         #    config:
     select:
     - '!shared_hierarchy.*'

--- a/meltano.yml
+++ b/meltano.yml
@@ -15,6 +15,8 @@ plugins:
       kind: password
     - name: time_entry_assignees
       kind: string
+    - name: time_entry_start_date
+      kind: string
         #    config:
     select:
     - '!shared_hierarchy.*'

--- a/tap_clickup/schemas/time_entries.json
+++ b/tap_clickup/schemas/time_entries.json
@@ -5,7 +5,7 @@
             "type": "string"
         },
         "task": {
-            "type": "object",
+            "type": ["object", "string"],
             "properties": {
                 "id": {
                     "type": "string"

--- a/tap_clickup/schemas/time_entries.json
+++ b/tap_clickup/schemas/time_entries.json
@@ -20,7 +20,7 @@
                             "type": "string"
                         },
                         "color": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         },
                         "type": {
                             "type": "string"
@@ -49,7 +49,7 @@
                         "type": "string"
                     },
                     "color": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
                     "initials": {
                         "type": "string"

--- a/tap_clickup/schemas/time_entries.json
+++ b/tap_clickup/schemas/time_entries.json
@@ -104,7 +104,7 @@
                     "type": ["string", "null"]
                 },
                 "space_id": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 }
             }
         },

--- a/tap_clickup/schemas/time_entries.json
+++ b/tap_clickup/schemas/time_entries.json
@@ -55,7 +55,7 @@
                         "type": "string"
                     },
                     "profilePicture": {
-                        "type": "null"
+                        "type": ["string", "null"]
                     }
                 }                    },
                 "billable": {

--- a/tap_clickup/schemas/time_entries.json
+++ b/tap_clickup/schemas/time_entries.json
@@ -98,7 +98,7 @@
             "type": "object",
             "properties": {
                 "list_id": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "folder_id": {
                     "type": "string"

--- a/tap_clickup/schemas/time_entries.json
+++ b/tap_clickup/schemas/time_entries.json
@@ -20,7 +20,10 @@
                             "type": "string"
                         },
                         "color": {
-                            "type": ["string", "null"]
+                            "type": [
+                                "string",
+                                "null"
+                            ]
                         },
                         "type": {
                             "type": "string"
@@ -28,76 +31,85 @@
                         "orderindex": {
                             "type": "integer"
                         }
-                    }                            },
-                    "custom_type": {
-                        "type": "null"
-                    }
-            }                    },
-            "wid": {
-                "type": "string"
-            },
-            "user": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer"
-                    },
-                    "username": {
-                        "type": "string"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "color": {
-                        "type": ["string", "null"]
-                    },
-                    "initials": {
-                        "type": "string"
-                    },
-                    "profilePicture": {
-                        "type": ["string", "null"]
-                    }
-                }                    },
-                "billable": {
-                    "type": "boolean"
-                },
-                "start": {
-                    "type": "string"
-                },
-                "end": {
-                    "type": "string"
-                },
-                "duration": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "tags": {
-                    "type": "array"
-                },
-                "source": {
-                    "type": "string"
-                },
-                "at": {
-                    "type": "string"
-                },
-                "task_location": {
-                    "type": "object",
-                    "properties": {
-                        "list_id": {
-                            "type": "string"
-                        },
-                        "folder_id": {
-                            "type": "string"
-                        },
-                        "space_id": {
-                            "type": "string"
-                        }
                     }
                 },
-                "task_url": {
+                "custom_type": {
+                    "type": "null"
+                }
+            }
+        },
+        "wid": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "color": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "initials": {
+                    "type": "string"
+                },
+                "profilePicture": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "billable": {
+            "type": "boolean"
+        },
+        "start": {
+            "type": "string"
+        },
+        "end": {
+            "type": "string"
+        },
+        "duration": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "tags": {
+            "type": "array"
+        },
+        "source": {
+            "type": "string"
+        },
+        "at": {
+            "type": "string"
+        },
+        "task_location": {
+            "type": "object",
+            "properties": {
+                "list_id": {
+                    "type": "string"
+                },
+                "folder_id": {
+                    "type": "string"
+                },
+                "space_id": {
                     "type": "string"
                 }
+            }
+        },
+        "task_url": {
+            "type": "string"
+        }
     }
 }

--- a/tap_clickup/schemas/time_entries.json
+++ b/tap_clickup/schemas/time_entries.json
@@ -101,7 +101,7 @@
                     "type": ["string", "null"]
                 },
                 "folder_id": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "space_id": {
                     "type": "string"

--- a/tap_clickup/schemas/time_entries.json
+++ b/tap_clickup/schemas/time_entries.json
@@ -34,7 +34,7 @@
                     }
                 },
                 "custom_type": {
-                    "type": "null"
+                    "type": ["null", "integer"]
                 }
             }
         },

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -1,5 +1,6 @@
 """Stream type classes for tap-clickup."""
 from pathlib import Path
+from time import mktime, strptime
 from typing import Optional, Any, Dict
 import requests
 from singer_sdk.helpers.jsonpath import extract_jsonpath
@@ -45,9 +46,16 @@ class TimeEntries(ClickUpStream):
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        # TODO: Use env vars for these otherwise use the values as we do below
-        params["assignee"] = self.config.get("time_entry_assignees")
-        # params["assignee"] = ",".join(context["user_ids"])
+
+        if "time_entry_start_date" in self.config:
+            # Formatted in ISO 8601, it must now be converted to milliseconds
+            print("MY TEST DATE", self.config["time_entry_start_date"])
+            start_date_in_ms = int(mktime(strptime(self.config["time_entry_start_date"], "%Y-%m-%d").timetuple()) * 1000)
+            params["start_date"] = start_date_in_ms
+        if "time_entry_assignees" in self.config:
+            params["assignee"] = self.config["time_entry_assignees"]
+        else:
+            params["assignee"] = ",".join(context["user_ids"])
         return params
 
 

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -20,7 +20,8 @@ class TeamsStream(ClickUpStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        user_ids = [member.get("user", {}).get("id") for member in record.get("members", []) if isinstance(member, dict)]
+        user_ids = [str(member.get("user", {}).get("id")) for member in record.get("members", []) if isinstance(member, dict)]
+
         return {
             "team_id": record["id"],
             "user_ids": user_ids
@@ -40,12 +41,11 @@ class TimeEntries(ClickUpStream):
     # TODO not clear why this is needed
     partitions = None
     def get_url_params(
-        self, context: Optional[dict], next_page_token: Optional[Any]
+            self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        if 'user_ids' in context:
-            params["user_ids"] = ",".join(context["user_ids"])
+        params["assignee"] = ",".join(context["user_ids"])
         return params
 
 

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -35,7 +35,7 @@ class TimeEntries(ClickUpStream):
     name = "time_entries"
     path = "/team/{team_id}/time_entries"
     primary_keys = ["id"]
-    replication_key = None
+    replication_key = "at"
     schema_filepath = SCHEMAS_DIR / "time_entries.json"
     records_jsonpath = "$.data[*]"
     parent_stream_type = TeamsStream

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -1,6 +1,6 @@
 """Stream type classes for tap-clickup."""
+from datetime import datetime
 from pathlib import Path
-from time import strptime
 from typing import Optional, Any, Dict
 import requests
 from singer_sdk.helpers.jsonpath import extract_jsonpath
@@ -49,7 +49,7 @@ class TimeEntries(ClickUpStream):
 
         if "time_entry_start_date" in self.config:
             # Formatted in ISO 8601, it must now be converted to milliseconds
-            start_date = strptime(self.config["time_entry_start_date"], "%Y-%m-%dT%H:%M:%SZ")
+            start_date = datetime.strptime(self.config["time_entry_start_date"], "%Y-%m-%dT%H:%M:%SZ")
             # Convert the datetime object to milliseconds
             params["start_date"] = int(start_date.timestamp() * 1000)
         if "time_entry_assignees" in self.config:

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -21,7 +21,8 @@ class TeamsStream(ClickUpStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        user_ids = [str(member.get("user", {}).get("id")) for member in record.get("members", []) if isinstance(member, dict)]
+        user_ids = [str(member.get("user", {}).get("id")) for member in record.get("members", []) if
+                    isinstance(member, dict)]
 
         return {
             "team_id": record["id"],
@@ -41,17 +42,21 @@ class TimeEntries(ClickUpStream):
     parent_stream_type = TeamsStream
     # TODO not clear why this is needed
     partitions = None
+
     def get_url_params(
             self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
 
-        if "time_entry_start_date" in self.config:
-            # Formatted in ISO 8601, it must now be converted to milliseconds
+        state_based_date = self.get_starting_replication_key_value(context)
+        # In the case of the first run, we need to use the start date from the config
+        if not state_based_date:
             start_date = datetime.strptime(self.config["time_entry_start_date"], "%Y-%m-%dT%H:%M:%SZ")
-            # Convert the datetime object to milliseconds
             params["start_date"] = int(start_date.timestamp() * 1000)
+        else:
+            # Because the state date is already in milliseconds, we can just use it
+            params["start_date"] = state_based_date
         if "time_entry_assignees" in self.config:
             params["assignee"] = self.config["time_entry_assignees"]
         else:

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -1,6 +1,6 @@
 """Stream type classes for tap-clickup."""
 from pathlib import Path
-from time import mktime, strptime
+from datetime import strptime
 from typing import Optional, Any, Dict
 import requests
 from singer_sdk.helpers.jsonpath import extract_jsonpath
@@ -49,9 +49,9 @@ class TimeEntries(ClickUpStream):
 
         if "time_entry_start_date" in self.config:
             # Formatted in ISO 8601, it must now be converted to milliseconds
-            print("MY TEST DATE", self.config["time_entry_start_date"])
-            start_date_in_ms = int(mktime(strptime(self.config["time_entry_start_date"], "%Y-%m-%d").timetuple()) * 1000)
-            params["start_date"] = start_date_in_ms
+            start_date = strptime(self.config["time_entry_start_date"], "%Y-%m-%dT%H:%M:%SZ")
+            # Convert the datetime object to milliseconds
+            params["start_date"] = int(start_date.timestamp() * 1000)
         if "time_entry_assignees" in self.config:
             params["assignee"] = self.config["time_entry_assignees"]
         else:

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -20,8 +20,10 @@ class TeamsStream(ClickUpStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
+        user_ids = [member.get("user", {}).get("id") for member in record.get("members", []) if isinstance(member, dict)]
         return {
             "team_id": record["id"],
+            "user_ids": user_ids
         }
 
 
@@ -37,6 +39,14 @@ class TimeEntries(ClickUpStream):
     parent_stream_type = TeamsStream
     # TODO not clear why this is needed
     partitions = None
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        params = super().get_url_params(context, next_page_token)
+        if 'user_ids' in context:
+            params["user_ids"] = ",".join(context["user_ids"])
+        return params
 
 
 class SpacesStream(ClickUpStream):

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -45,7 +45,9 @@ class TimeEntries(ClickUpStream):
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)
-        params["assignee"] = ",".join(context["user_ids"])
+        # TODO: Use env vars for these otherwise use the values as we do below
+        params["assignee"] = self.config.get("time_entry_assignees")
+        # params["assignee"] = ",".join(context["user_ids"])
         return params
 
 

--- a/tap_clickup/streams.py
+++ b/tap_clickup/streams.py
@@ -1,6 +1,6 @@
 """Stream type classes for tap-clickup."""
 from pathlib import Path
-from datetime import strptime
+from time import strptime
 from typing import Optional, Any, Dict
 import requests
 from singer_sdk.helpers.jsonpath import extract_jsonpath

--- a/tap_clickup/tap.py
+++ b/tap_clickup/tap.py
@@ -60,8 +60,9 @@ class TapClickUp(Tap):
             th.StringType,
             required=False,
             description="""The start date that determines how far back in time the extractor gets time entries.
-            Without this, only the last thirty days of time entries will be fetched.
-            Ex. '2023-01-01T00:00:00Z' to follow singer date format."""
+            Without this, only the last thirty days of time entries will be fetched. After the initial run,
+            this value will be ignored in favor of the state, using the replication_key of 'at' to determine the
+            start date. Ex. '2023-01-01T00:00:00Z' to follow singer date format."""
         ),
         # Removing "official" start_date support re https://github.com/AutoIDM/tap-clickup/issues/118
         #        th.Property(

--- a/tap_clickup/tap.py
+++ b/tap_clickup/tap.py
@@ -47,6 +47,14 @@ class TapClickUp(Tap):
         th.Property(
             "api_token", th.StringType, required=True, description="Example: 'pk_12345"
         ),
+         th.Property(
+            "time_entry_assignees",
+            th.StringType,
+            required=False,
+            description="""By default, the extractor will get all user ids from your
+            team and use them when fetching time entries. If you want to fetch time entries
+            assigned to specific users, provide a comma-separated list of user IDs here. Ex. '420230,452346,784219'"""
+        ),
         # Removing "official" start_date support re https://github.com/AutoIDM/tap-clickup/issues/118
         #        th.Property(
         #            "start_date",

--- a/tap_clickup/tap.py
+++ b/tap_clickup/tap.py
@@ -47,13 +47,21 @@ class TapClickUp(Tap):
         th.Property(
             "api_token", th.StringType, required=True, description="Example: 'pk_12345"
         ),
-         th.Property(
+        th.Property(
             "time_entry_assignees",
             th.StringType,
             required=False,
             description="""By default, the extractor will get all user ids from your
             team and use them when fetching time entries. If you want to fetch time entries
             assigned to specific users, provide a comma-separated list of user IDs here. Ex. '420230,452346,784219'"""
+        ),
+        th.Property(
+            "time_entry_start_date",
+            th.StringType,
+            required=False,
+            description="""The start date that determines how far back in time the extractor gets time entries.
+            Without this, only the last thirty days of time entries will be fetched.
+            Ex. '2023-01-01T00:00:00Z' to follow singer date format."""
         ),
         # Removing "official" start_date support re https://github.com/AutoIDM/tap-clickup/issues/118
         #        th.Property(


### PR DESCRIPTION
- Added two new settings for clickup time entries
   - **time_entry_start_date**: The start date that determines how far back in time the extractor gets time entries.
   - **time_entry_assignees**: used to fetch time entries assigned to specific users
- Updated the schema for time entries. It seems with the release of clickup mobile, there are sometimes null entries for certain properties. I've reached out to clickup support to validate whether this is intentional
- Made the 'at' field of the time entry stream the replication key, since for this particular endpoint, it serves as the update_at field. 

Notes:
_The **time_entry_start_date** might be overkill but currently there isn't a query param we can use for this endpoint that allows us to query for entries that have changed. Something like **date_updated_gt** from the get tasks endpoint would be great here_

_The new default behavior for time entries will be to get the entries of ALL users in your team. If you want only a subset of assignees you can use the **time_entry_assignees** conf._ 